### PR TITLE
refactor: use project group as groupId instead of custom one

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,6 @@ allprojects {
         pom {
             scmConnection = "https://github.com/eclipse-dataspacetck/dsp-tck.git"
             scmUrl = "scm:git:git@github.com:eclipse-dataspacetck/dsp-tck.git"
-            groupId = "org.eclipse.dataspacetck.build"
             projectName = project.name
             description = "DSP Technology Compatibility Kit"
             projectUrl = "https://projects.eclipse.org/projects/technology.dataspacetck"

--- a/plugins/tck-build-plugin/src/main/java/org/eclipse/dataspacetck/gradle/tckbuild/conventions/PublicationConvention.java
+++ b/plugins/tck-build-plugin/src/main/java/org/eclipse/dataspacetck/gradle/tckbuild/conventions/PublicationConvention.java
@@ -48,7 +48,7 @@ public class PublicationConvention {
                 pe.publications(publications -> publications.create(target.getName(), MavenPublication.class,
                         mavenPublication -> {
                             mavenPublication.from(target.getComponents().getByName("java"));
-                            mavenPublication.setGroupId(buildExt.getPom().getGroupId().get());
+                            mavenPublication.setGroupId(target.getGroup().toString());
                             mavenPublication.suppressPomMetadataWarningsFor("testFixturesApiElements");
                             mavenPublication.suppressPomMetadataWarningsFor("testFixturesRuntimeElements");
                         }));

--- a/plugins/tck-build-plugin/src/main/java/org/eclipse/dataspacetck/gradle/tckbuild/extensions/PomExtension.java
+++ b/plugins/tck-build-plugin/src/main/java/org/eclipse/dataspacetck/gradle/tckbuild/extensions/PomExtension.java
@@ -52,6 +52,7 @@ public abstract class PomExtension {
 
     public abstract Property<String> getScmUrl();
 
+    @Deprecated(since = "1.0.0")
     public abstract Property<String> getGroupId();
 
 }


### PR DESCRIPTION
## What this PR changes/adds

Use project `group` as default groupId.
Keep usage of PomExtension.getGroupId to permit smoother migration, but it has been deprecated.

## Why it does that

simplification. currently gradle throws nasty exceptions if groupId is not explicitly set

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
